### PR TITLE
[dev] UserContainer PlusIcon 클릭 시 Team 나누기

### DIFF
--- a/client/src/components/Desktop/BlueTeam.tsx
+++ b/client/src/components/Desktop/BlueTeam.tsx
@@ -1,12 +1,16 @@
 import none from "./../../assets/line_img/line-none.png";
-import sett from "./../../assets/sett.png";
 import tier from "./../../assets/tier.png";
+import PlusIcon from "../../assets/svg/add.svg";
 
 import { useState } from "react";
 
 import LineModal from "../Mobile/chooseUser/LineModal";
+import { User } from "../../commonTypes";
 
-const BlueTeam = () => {
+interface BlueTeamProps {
+  user?: User;
+}
+const BlueTeam: React.FC<BlueTeamProps> = ({ user }) => {
   const [isLine, setIsLine] = useState<boolean>(false);
   const [line, setLine] = useState(none);
   return (
@@ -19,18 +23,20 @@ const BlueTeam = () => {
       />
       <div className="w-[100%]">
         <ul>
-          <li className="flex flex-row items-center justify-between">
-            <img src={sett} alt="most" className="w-8 h-8" />
-            <p className="text-xs">승률 50.2%</p>
-          </li>
-          <li className="flex flex-row items-center justify-between">
-            <img src={sett} alt="most" className="w-8 h-8" />
-            <p className="text-xs">승률 50.2%</p>
-          </li>
-          <li className="flex flex-row items-center justify-between">
-            <img src={sett} alt="most" className="w-8 h-8" />
-            <p className="text-xs">승률 50.2%</p>
-          </li>
+          {/* 유저 정보가 있을 경우 */}
+          {user ? (
+            <li
+              key={user.id}
+              className="flex flex-row items-center justify-between"
+            >
+              <p className="text-xs font-bold">{user.nickname}</p>
+            </li>
+          ) : (
+            // 유저 정보가 없을 경우
+            <li className="text-center text-gray-500">
+              <img src={PlusIcon} alt="Add" className="" />
+            </li>
+          )}
         </ul>
       </div>
       <p className="text-xs overflow-hidden text-ellipsis text-nowrap">

--- a/client/src/components/Desktop/Menu.tsx
+++ b/client/src/components/Desktop/Menu.tsx
@@ -3,16 +3,28 @@ import UserContainer from "./UserContainer";
 import ModalButton from "./ModalButton";
 import ComposeButton from "./ComposeButton";
 
+import { User } from "../../commonTypes";
+
 interface MenuProps {
   setHeaderText: (text: string) => void;
+  allUser: User[];
+  redTeam: User[];
+  blueTeam: User[];
+  setRedTeam: (team: User[]) => void;
+  setBlueTeam: (team: User[]) => void;
+  onAddUserToTeam: (user: User) => void;
 }
 
-const Menu: React.FC<MenuProps> = ({ setHeaderText }) => {
+const Menu: React.FC<MenuProps> = ({
+  setHeaderText,
+  allUser,
+  onAddUserToTeam,
+}) => {
   return (
     <div className="relative">
       <ModalButton setHeaderText={setHeaderText} />
       <div className="lg:col-span-1 lg:row-span-3">
-        <UserContainer />
+        <UserContainer allUser={allUser} onAddUser={onAddUserToTeam} />
       </div>
       <ComposeButton />
     </div>

--- a/client/src/components/Desktop/RedTeam.tsx
+++ b/client/src/components/Desktop/RedTeam.tsx
@@ -1,12 +1,17 @@
 import none from "./../../assets/line_img/line-none.png";
-import sett from "./../../assets/sett.png";
 import tier from "./../../assets/tier.png";
+import PlusIcon from "../../assets/svg/add.svg";
 
 import { useState } from "react";
 
 import LineModal from "../Mobile/chooseUser/LineModal";
+import { User } from "../../commonTypes";
 
-const RedTeam = () => {
+interface RedTeamProps {
+  user?: User;
+}
+
+const RedTeam: React.FC<RedTeamProps> = ({ user }) => {
   const [isLine, setIsLine] = useState<boolean>(false);
   const [line, setLine] = useState(none);
   return (
@@ -19,25 +24,27 @@ const RedTeam = () => {
       />
       <div className="w-[100%]">
         <ul>
-          <li className="flex flex-row items-center justify-between">
-            <img src={sett} alt="most" className="w-8 h-8" />
-            <p className="text-xs">승률 50.2%</p>
-          </li>
-          <li className="flex flex-row items-center justify-between">
-            <img src={sett} alt="most" className="w-8 h-8" />
-            <p className="text-xs">승률 50.2%</p>
-          </li>
-          <li className="flex flex-row items-center justify-between">
-            <img src={sett} alt="most" className="w-8 h-8" />
-            <p className="text-xs">승률 50.2%</p>
-          </li>
+          {/* 유저 정보가 있을 경우 */}
+          {user ? (
+            <li
+              key={user.id}
+              className="flex flex-row items-center justify-between"
+            >
+              <p className="text-xs font-bold">{user.nickname}</p>
+            </li>
+          ) : (
+            // 유저 정보가 없을 경우
+            <li className="text-center text-gray-500">
+              <img src={PlusIcon} alt="Add" className="" />
+            </li>
+          )}
         </ul>
+        <p className="text-xs overflow-hidden text-ellipsis text-nowrap">
+          닉네임닉네입니다#KR1
+        </p>
+        <img src={tier} alt="tier" className="h-9" />
+        {isLine && <LineModal setLine={setLine} setIsLine={setIsLine} />}
       </div>
-      <p className="text-xs overflow-hidden text-ellipsis text-nowrap">
-        닉네임닉네입니다#KR1
-      </p>
-      <img src={tier} alt="tier" className="h-9" />
-      {isLine && <LineModal setLine={setLine} setIsLine={setIsLine} />}
     </div>
   );
 };

--- a/client/src/components/Desktop/Team.tsx
+++ b/client/src/components/Desktop/Team.tsx
@@ -1,8 +1,14 @@
 import BlueTeam from "./BlueTeam";
 import RedTeam from "./RedTeam";
 import Versus from "./Versus";
+import { User } from "../../commonTypes";
 
-export default function Team() {
+interface TeamProps {
+  redTeam: User[];
+  blueTeam: User[];
+}
+
+const Team: React.FC<TeamProps> = ({ redTeam, blueTeam }) => {
   const redTeamCount = 5;
   const blueTeamCount = 5;
   return (
@@ -10,7 +16,7 @@ export default function Team() {
       {/* Red Team 영역 */}
       <div className="w-[100%] h-[100%] flex xs:gap-[10px] lg:gap-[15px] xl:gap-[25px] justify-center">
         {Array.from({ length: redTeamCount }).map((_, idx) => (
-          <RedTeam key={idx} />
+          <RedTeam key={idx} user={redTeam[idx]} />
         ))}
       </div>
       <div>
@@ -19,9 +25,11 @@ export default function Team() {
       {/* Blue Team 영역 */}
       <div className="w-[100%] h-[100%] flex xs:gap-[10px] lg:gap-[15px] xl:gap-[25px] justify-center">
         {Array.from({ length: blueTeamCount }).map((_, idx) => (
-          <BlueTeam key={idx} />
+          <BlueTeam key={idx} user={blueTeam[idx]} />
         ))}
       </div>
     </div>
   );
-}
+};
+
+export default Team;

--- a/client/src/components/Desktop/UserContainer.tsx
+++ b/client/src/components/Desktop/UserContainer.tsx
@@ -1,13 +1,36 @@
 import React from "react";
-import { Props } from "../../commonTypes";
+import { User } from "../../commonTypes";
+import PlusIcon from "../../assets/svg/add.svg";
 
-const UserContainer = ({ children }: Props) => {
+interface UserContainerProps {
+  allUser: User[];
+  onAddUser: (userId: number) => void;
+}
+
+const UserContainer: React.FC<UserContainerProps> = ({
+  allUser,
+  onAddUser,
+}) => {
   return (
     <div>
       <div className="w-[100%] h-[70vh] overflow-auto bg-[#F0E6D2] border border-solid border-[#C89B3C] rounded-2xl bg-[#F0E6D2] bg-opacity-30 p-4">
         <div className="ml-3 mb-5 mt-3">최근에 같이한 친구</div>
-
-        {children}
+        <ul>
+          {allUser.map((user) => (
+            <li key={user.id} className="mb-2">
+              <div className="flex gap-[5px] justify-center">
+                <span className="font-bold">{user.nickname}</span>
+                <span>{user.winRate}%</span>
+                <img
+                  src={PlusIcon}
+                  alt="Add"
+                  className="cursor-pointer w-6 h-6"
+                  onClick={() => onAddUser(user.id)}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/client/src/page/Desktop-MainPage.tsx
+++ b/client/src/page/Desktop-MainPage.tsx
@@ -3,14 +3,32 @@ import Header from "../components/Desktop/Header";
 import Menu from "../components/Desktop/Menu";
 import { useState } from "react";
 
-const DesktopMainPage = () => {
+import { User } from "../commonTypes";
+
+interface DesktopMainPageProps {
+  allUser: User[];
+  redTeam: User[];
+  blueTeam: User[];
+  onAddUserToTeam: (userId: number) => void;
+}
+
+const DesktopMainPage: React.FC<DesktopMainPageProps> = ({
+  allUser,
+  redTeam,
+  blueTeam,
+  onAddUserToTeam,
+}) => {
   const [headerText, setHeaderText] = useState<string>("모드를 선택해주세요");
   return (
     <div className="w-[100vw] xs:h-[100%] lg:h-[100vh]">
       <Header text={headerText} />
       <div className="lg:grid lg:grid-rows-3 lg:grid-cols-3 gap-6 lg:w-[100%] lg:h-[70%] px-[50px]">
-        <Team />
-        <Menu setHeaderText={setHeaderText} />
+        <Team redTeam={redTeam} blueTeam={blueTeam} />
+        <Menu
+          setHeaderText={setHeaderText}
+          allUser={allUser}
+          onAddUserToTeam={onAddUserToTeam}
+        />
       </div>
     </div>
   );

--- a/client/src/page/MainPage.tsx
+++ b/client/src/page/MainPage.tsx
@@ -4,11 +4,43 @@ import DesktopMainPage from "./Desktop-MainPage";
 
 import { User } from "../commonTypes";
 
-export default function MainPage() {
-  const [allUser, setAllUser] = useState<User[]>([]);
-  const [isMobile, setIsMobile] = useState(window.innerWidth < 700);
+const MainPage = () => {
+  // 유저 데이터 저장
+  const [allUser, setAllUser] = useState<User[]>([
+    { id: 1, nickname: "User1", winRate: 50.4 },
+    { id: 2, nickname: "User2", winRate: 52.1 },
+    { id: 3, nickname: "User3", winRate: 49.5 },
+    { id: 4, nickname: "User4", winRate: 48.9 },
+    { id: 5, nickname: "User5", winRate: 53.3 },
+    { id: 6, nickname: "User6", winRate: 51.2 },
+    { id: 7, nickname: "User7", winRate: 47.8 },
+    { id: 8, nickname: "User8", winRate: 50.0 },
+    { id: 9, nickname: "User9", winRate: 49.1 },
+    { id: 10, nickname: "User10", winRate: 52.7 },
+  ]);
 
-  const [modalType, setModalType] = useState<string | null>(null); // 현재 열리는 모달 타입
+  // 레드팀, 블루팀 데이터
+  const [redTeam, setRedTeam] = useState<User[]>([]);
+  const [blueTeam, setBlueTeam] = useState<User[]>([]);
+
+  // 사용자 추가 핸들러
+  const handleAddUserToTeam = (userId: number) => {
+    const selectedUser = allUser.find((user) => user.id === userId);
+    if (!selectedUser) return;
+
+    // Redteam -> BlueTeam 순서로 추가
+    if (redTeam.length <= blueTeam.length) {
+      setRedTeam([...redTeam, selectedUser]);
+    } else {
+      setBlueTeam([...blueTeam, selectedUser]);
+    }
+
+    // allUser에서 제거
+    setAllUser(allUser.filter((user) => user.id !== userId));
+  };
+
+  // 모바일 / 데스크탑 크기 구분
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 700);
 
   // 화면 크기 변화에 따른 상태 업데이트
   useEffect(() => {
@@ -25,5 +57,20 @@ export default function MainPage() {
     };
   });
 
-  return <div>{isMobile ? <MobileMainpage /> : <DesktopMainPage />}</div>;
-}
+  return (
+    <div>
+      {isMobile ? (
+        <MobileMainpage />
+      ) : (
+        <DesktopMainPage
+          allUser={allUser}
+          redTeam={redTeam}
+          blueTeam={blueTeam}
+          onAddUserToTeam={handleAddUserToTeam}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MainPage;


### PR DESCRIPTION
- [dev] UserContainer PlusIcon 클릭 시 Team 나누기

## 🔘Part

- FE

<br/>

## 🔎 작업 내용

- MainPage 최상위 컴포넌트에 allUser가 저장되는 예시 배열을 만들어 UserContainer에서 +하면 RedTeam, BlueTeam으로 순차적으로 User를 나누는 기능 개발

  <br/>

## 🔧 앞으로의 과제

- 현재는 RedTeam, BlueTeam에 +버튼만 UserId로 추가되는 구성이지만, 라인, 아이디, 티어등 여러가지 데이터를 전달하는 기능
- RedTeam, BlueTeam에서 삭제버튼(-)클릭 시 다시 UserContainer로 User가 돌아가는 기능
- 팀 구성 버튼 클릭 시 Random하게 또는 Balance하게 팀을 구성해서 RedTeam, BlueTeam으로 유저를 전달하는 기능

  <br/>
