### PR TITLE
[fix] mobile 뷰 상태관리 로직 수정

### DIFF
--- a/client/src/components/Desktop/Menu.tsx
+++ b/client/src/components/Desktop/Menu.tsx
@@ -39,7 +39,12 @@ const Menu: React.FC<MenuProps> = ({
         isDraftModalOpen={isDraftModalOpen}
       />
       <div className="lg:col-span-1 lg:row-span-3">
-        <UserContainer allUsers={allUsers} handleAddUser={handleAddUser} />
+        <UserContainer
+          allUsers={allUsers.filter(
+            (user) => !addedUsers.some((u) => u.id === user.id)
+          )}
+          handleAddUser={handleAddUser}
+        />
       </div>
     </div>
   );

--- a/client/src/page/MainPage.tsx
+++ b/client/src/page/MainPage.tsx
@@ -74,8 +74,12 @@ const MainPage = () => {
 
   const sharedProps = {
     allUsers,
+    addedUsers,
+    setAddedUsers,
     redTeam,
+    setRedTeam,
     blueTeam,
+    setBlueTeam,
     handleAddUser: handleAddUser,
     handleRemoveUser: handleRemoveUser,
     modalType,

--- a/client/src/page/Mobile-Mainpage.tsx
+++ b/client/src/page/Mobile-Mainpage.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import UserContainer from "../components/Mobile/chooseUser/UserContainer";
 import AddUserModal from "./mainPageModal/AddUserModal";
 import SelectModeModal from "./mainPageModal/SelectModeModal";
@@ -15,9 +14,15 @@ interface Props {
   setIsDraftModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedMode: React.Dispatch<React.SetStateAction<string>>;
   setHeaderText: React.Dispatch<React.SetStateAction<string>>;
+  setRedTeam: React.Dispatch<React.SetStateAction<User[]>>;
+  setBlueTeam: React.Dispatch<React.SetStateAction<User[]>>;
+  setAddedUsers: React.Dispatch<React.SetStateAction<User[]>>;
   selectedMode: string;
   modalType: string;
   isDraftModalOpen: boolean;
+  addedUsers: User[];
+  redTeam: User[];
+  blueTeam: User[];
 }
 
 const MobileMainpage = ({
@@ -29,10 +34,16 @@ const MobileMainpage = ({
   modalType,
   isDraftModalOpen,
   setHeaderText,
+  redTeam,
+  blueTeam,
+  addedUsers,
+  setRedTeam,
+  setBlueTeam,
+  setAddedUsers,
 }: Props) => {
-  const [addedUsers, setAddedUsers] = useState<User[]>([]);
-  const [redTeam, setRedTeam] = useState<User[]>([]); // RedTeam 유저 목록
-  const [blueTeam, setBlueTeam] = useState<User[]>([]); // BlueTeam 유저 목록
+  // const [addedUsers, setAddedUsers] = useState<User[]>([]);
+  // const [redTeam, setRedTeam] = useState<User[]>([]); // RedTeam 유저 목록
+  // const [blueTeam, setBlueTeam] = useState<User[]>([]); // BlueTeam 유저 목록
   // const [modalType, setModalType] = useState<string | null>(null); // 현재 열리는 모달 타입
   // const [isDraftModalOpen, setIsDraftModalOpen] = useState(false); // DraftModal 상태 관리
   // const [selectedMode, setSelectedMode] = useState<string>("RANDOM"); // 선택된 모드 상태
@@ -106,6 +117,13 @@ const MobileMainpage = ({
       >
         팀짜기
       </button>
+      {/* 최근 함께한 유저 목록 */}
+      <UserContainer
+        users={allUsers.filter(
+          (user) => !addedUsers.some((u) => u.id === user.id)
+        )}
+        onAddUser={addUser}
+      />
 
       {/* 모달들 */}
       {modalType === "addUser" && (
@@ -136,13 +154,6 @@ const MobileMainpage = ({
           teamMembers={allUsers}
         />
       )}
-
-      <UserContainer
-        users={allUsers.filter(
-          (user) => !addedUsers.some((u) => u.id === user.id)
-        )}
-        onAddUser={addUser}
-      />
     </div>
   );
 };

--- a/client/src/page/mainPageModal/AddUserModal.tsx
+++ b/client/src/page/mainPageModal/AddUserModal.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import apiCall from "../../Api/Api";
-import { error } from "console";
 
 // ModalProps 수정
 interface ModalProps {

--- a/server/controllers/userInfoController.js
+++ b/server/controllers/userInfoController.js
@@ -157,6 +157,7 @@ const userAdd = async (req, res) => {
   const { userid, tagLine } = req.body;
 
   console.log("세션 : ", req.session);
+  console.log("세션ID", req.session.id);
 
   if (!userid || !tagLine) {
     return res.status(400).json({ message: "소환사 명을 입력하세요" });
@@ -177,7 +178,7 @@ const userAdd = async (req, res) => {
     } else {
       // DB 저장: 사용자 정보
       const user = await NoobsRecentFriend.create({
-        user_id: userid, // 세션에서 가져온 user_id 값
+        user_id: req.session.user.id, // 세션에서 가져온 user_id 값
         gameName: userSearchData.gameName,
         tagLine: userSearchData.tagLine,
         profileIconId: userSearchData.profileIconId,


### PR DESCRIPTION
- 제목 : [fix] mobile 뷰 상태관리 로직 수정

## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- 유저 상태관리 로직을 mobile-mainpage -> mainpage로 이동했습니다.

- 이제 mobile 뷰에서 유저를 이동해도 desktop뷰 에서도 똑같이 실행됩니다.

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

- desktop뷰에서도 취소버튼까지 똑같이 실행되도록 수정하기

  <br/>

## ➕ 이슈 링크

