### PR TITLE
[dev] RedTeam, BlueTeam 취소 시 UserContainer에 보여주기

### DIFF
--- a/client/src/components/Desktop/BlueTeam.tsx
+++ b/client/src/components/Desktop/BlueTeam.tsx
@@ -10,8 +10,14 @@ import { User } from "../../commonTypes";
 
 interface BlueTeamProps {
   user?: User;
+  handleRemoveUser: (user: User) => void;
+  handleAddUser: (user: User) => void;
 }
-const BlueTeam: React.FC<BlueTeamProps> = ({ user }) => {
+const BlueTeam: React.FC<BlueTeamProps> = ({
+  user,
+  handleRemoveUser,
+  handleAddUser,
+}) => {
   const [isLine, setIsLine] = useState<boolean>(false);
   const [line, setLine] = useState(none);
 
@@ -38,7 +44,15 @@ const BlueTeam: React.FC<BlueTeamProps> = ({ user }) => {
             <p className="text-xs font-bold">{user.nickname}</p>
             <img src={tier} alt="tier" className="h-9" />
             {isLine && <LineModal setLine={setLine} setIsLine={setIsLine} />}
-            <img src={close} alt="close" />
+            <img
+              src={close}
+              alt="close"
+              className="w-5 h-5 cursor-pointer"
+              onClick={() => {
+                handleRemoveUser(user);
+                handleAddUser(user);
+              }}
+            />
           </li>
         ) : (
           // 유저 정보가 없을 경우

--- a/client/src/components/Desktop/Menu.tsx
+++ b/client/src/components/Desktop/Menu.tsx
@@ -15,7 +15,7 @@ interface MenuProps {
   modalType: string;
   isDraftModalOpen: boolean;
   addedUsers: User[];
-  setAddedUsers: React.Dispatch<React.SetStateAction<string>>;
+  setAddedUsers: React.Dispatch<React.SetStateAction<User[]>>;
 }
 
 const Menu: React.FC<MenuProps> = ({
@@ -29,6 +29,7 @@ const Menu: React.FC<MenuProps> = ({
   modalType,
   isDraftModalOpen,
   addedUsers,
+  setAddedUsers,
 }) => {
   return (
     <div className="relative">
@@ -47,6 +48,7 @@ const Menu: React.FC<MenuProps> = ({
             (user) => !addedUsers.some((u) => u.id === user.id)
           )}
           handleAddUser={handleAddUser}
+          setAddedUsers={setAddedUsers}
         />
       </div>
     </div>

--- a/client/src/components/Desktop/Team.tsx
+++ b/client/src/components/Desktop/Team.tsx
@@ -45,7 +45,12 @@ const Team: React.FC<TeamProps> = ({
       {/* Blue Team 영역 */}
       <div className="w-[100%] h-[100%] flex xs:gap-[10px] lg:gap-[15px] xl:gap-[25px] justify-center">
         {blueTeamWithDefault.map((user, idx) => (
-          <BlueTeam key={idx} user={user} />
+          <BlueTeam
+            key={idx}
+            user={user}
+            handleRemoveUser={handleRemoveUser}
+            handleAddUser={handleAddUser}
+          />
         ))}
       </div>
     </div>

--- a/client/src/components/Desktop/UserContainer.tsx
+++ b/client/src/components/Desktop/UserContainer.tsx
@@ -5,11 +5,13 @@ import PlusIcon from "../../assets/svg/add.svg";
 interface UserContainerProps {
   allUsers: User[];
   handleAddUser: (user: User) => void;
+  setAddedUsers: React.Dispatch<React.SetStateAction<User[]>>;
 }
 
 const UserContainer: React.FC<UserContainerProps> = ({
   allUsers,
   handleAddUser,
+  setAddedUsers,
 }) => {
   return (
     <div>

--- a/client/src/page/Desktop-MainPage.tsx
+++ b/client/src/page/Desktop-MainPage.tsx
@@ -17,7 +17,7 @@ interface DesktopMainPageProps {
   setSelectedMode: React.Dispatch<React.SetStateAction<string>>;
   setHeaderText: React.Dispatch<React.SetStateAction<string>>;
   addedUsers: User[];
-  setAddedUser: React.Dispatch<React.SetStateAction<User[]>>;
+  setAddedUsers: React.Dispatch<React.SetStateAction<User[]>>;
   selectedMode: string;
   modalType: string;
   isDraftModalOpen: boolean;

--- a/client/src/page/MainPage.tsx
+++ b/client/src/page/MainPage.tsx
@@ -42,8 +42,11 @@ const MainPage = () => {
       setBlueTeam([...blueTeam, selectedUser]);
     }
 
-    // allUser에서 제거
-    setAllUsers(allUsers.filter((u) => u.id !== user.id));
+    // allUsers에서 제거
+    setAllUsers((prev) => prev.filter((u) => u.id !== user.id));
+
+    // addedUsers에 추가
+    setAddedUsers((prev) => [...prev, user]);
   };
 
   // 팀에서 사용자 제거 로직
@@ -54,8 +57,12 @@ const MainPage = () => {
     } else if (blueTeam.some((u) => u.id === user.id)) {
       setBlueTeam((prev) => prev.filter((u) => u.id !== user.id));
     }
-    // 제거된 사용자를 allUsers에 다시 추가
-    setAddedUsers((prev) => [...prev, user]);
+
+    // addedUser에서 제거
+    setAddedUsers((prev) => prev.filter((u) => u.id !== user.id));
+
+    // allUser에서 생성
+    setAllUsers((prev) => [...prev, user]);
   };
 
   // 모바일 / 데스크탑 크기 구분


### PR DESCRIPTION
- 제목 : [dev] RedTeam, BlueTeam 취소 시 UserContainer에 보여주기
## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- [dev] RedTeam, BlueTeam 취소 시 UserContainer에 보여주기(addedUsers, allUsers 사용)
- 기존 allUsers에 저장되어있는 값을 + 버튼 클릭 시 addedUsers에 추가, RedTeam, BlueTeam에서 addedUsers에 추가되어있는 값을 x 버튼 클릭 시 allUsers에 추가


## 🔧 앞으로의 과제

- api 적용 후 테스트 필요

  <br/>