### PR TITLE
[fix] 전체 유저 불러오는 의존성 배열 추가 

### DIFF
--- a/client/src/commonTypes.ts
+++ b/client/src/commonTypes.ts
@@ -17,7 +17,7 @@ interface MostChamp {
 
 // user profile 관련 정보
 interface profileInfo {
-  profileImg: string;
+  Profile_img: string;
 }
 
 interface tierImg {
@@ -32,7 +32,7 @@ interface tierScore {
 export interface User {
   id: number; // 유저 고유 식별자
   Line?: string;
-  MostChamp: MostChamp[];
+  MostChamp: MostChamp;
   profileInfo: profileInfo;
   tierImg: tierImg;
   tierScore: tierScore;

--- a/client/src/components/Mobile/chooseUser/LatestUserInfo.tsx
+++ b/client/src/components/Mobile/chooseUser/LatestUserInfo.tsx
@@ -4,10 +4,11 @@ interface LatestUserInfoProps {
   onAddUser: (user: User) => void;
 }
 const LatestUserInfo: React.FC<LatestUserInfoProps> = ({ user, onAddUser }) => {
+  console.log("모스트", user.MostChamp);
   return (
     <div className="flex flex-row items-center h-[55px] mx-2 my-1 gap-2 relative">
       <img
-        src={`${user.MostChamp[0].champInfo.champ_img}`}
+        src={`${user.profileInfo.Profile_img}`}
         alt="most-champ-info"
         className="w-[20px] h-[20px]"
       />

--- a/client/src/page/MainPage.tsx
+++ b/client/src/page/MainPage.tsx
@@ -8,18 +8,7 @@ import apiCall from "../Api/Api";
 const MainPage = () => {
   const [isUserAdded, setIsUserAdded] = useState<boolean>(false);
   // 유저 데이터 저장
-  const [allUsers, setAllUsers] = useState<User[]>([
-    // { id: 1, nickname: "User1", winRate: 50.4 },
-    // { id: 2, nickname: "User2", winRate: 52.1 },
-    // { id: 3, nickname: "User3", winRate: 49.5 },
-    // { id: 4, nickname: "User4", winRate: 48.9 },
-    // { id: 5, nickname: "User5", winRate: 53.3 },
-    // { id: 6, nickname: "User6", winRate: 51.2 },
-    // { id: 7, nickname: "User7", winRate: 47.8 },
-    // { id: 8, nickname: "User8", winRate: 50.0 },
-    // { id: 9, nickname: "User9", winRate: 49.1 },
-    // { id: 10, nickname: "User10", winRate: 52.7 },
-  ]);
+  const [allUsers, setAllUsers] = useState<User[]>([]);
   console.log("현재 기본 isUserAdded", isUserAdded);
   // 최근 함께한 유저 불러오기
   useEffect(() => {
@@ -35,6 +24,7 @@ const MainPage = () => {
     };
     fetchData();
   }, [isUserAdded]);
+
   const [modalType, setModalType] = useState<string>(""); // 현재 열리는 모달 타입
   const [isDraftModalOpen, setIsDraftModalOpen] = useState(false); // DraftModal 상태 관리
   const [selectedMode, setSelectedMode] = useState<string>("모드선택"); // 선택된 모드 상태

--- a/client/src/page/mainPageModal/AddUserModal.tsx
+++ b/client/src/page/mainPageModal/AddUserModal.tsx
@@ -5,7 +5,7 @@ import apiCall from "../../Api/Api";
 interface ModalProps {
   closeModal: () => void;
   isModalOpen: boolean; // isModalOpen 속성 추가
-  setIsUserAdded: (value: boolean) => void;
+  setIsUserAdded: React.Dispatch<React.SetStateAction<boolean>>;
   isUserAdded: boolean;
 }
 
@@ -53,18 +53,17 @@ export default function AddUserModal({
     const [nickname, tag] = nicknameTag.split("#");
     const data = { userid: nickname, tagLine: tag };
     try {
-      const response = apiCall("noobs/lolUserAdd", "post", data);
+      const response = await apiCall("noobs/lolUserAdd", "post", data);
       console.log(response);
-      setIsUserAdded(true);
-      console.log("isUserAdded 상태변경", isUserAdded);
+      setIsUserAdded((prev) => !prev);
     } catch (err) {
       console.log(err);
     }
-
+    console.log("isUserAdded 상태변경", isUserAdded);
     // 추가 버튼 클릭 시 초기화
     setNicknameTag(""); // 입력 필드 초기화
     setUserAdded(null); // 유저 추가 완료/실패 문구 초기화
-    setIsUserAdded(false);
+
     console.log("isUserAdded 상태 초기화", isUserAdded);
   };
 


### PR DESCRIPTION
- 제목 : [fix] 전체 유저 불러오는 의존성 배열 추가 

## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- 전체 유저를 불러올 시에 의존성 배열을 추가했습니다.

- 해당 api는 인원추가가 일어날 시에만 추가됩니다.

  <br/>

## 이미지 첨부


<br/>

## 🔧 앞으로의 과제

- 유저 삭제 및 프로필 페이지 구현

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
