### PR TITLE
[fix] 추가된 user가 10명이 넘을 시, 추가를 하지 못하도록 수정/ [fix] 프로필 클릭과, 추가버튼 이벤트 버블링 방지/[feat] user id 값 전달

### DIFF
--- a/client/src/components/Desktop/LatestUserInfo.tsx
+++ b/client/src/components/Desktop/LatestUserInfo.tsx
@@ -55,7 +55,10 @@ const LatestUserInfo: React.FC<LatestUserInfoProps> = ({
         승률 {user.winRate}%
       </p>
       <button
-        onClick={() => onAddUser(user)}
+        onClick={(e) => {
+          onAddUser(user);
+          e.stopPropagation();
+        }}
         className="w-[10px] bg-inherit text-white"
       >
         +

--- a/client/src/components/Mobile/chooseUser/LatestUserInfo.tsx
+++ b/client/src/components/Mobile/chooseUser/LatestUserInfo.tsx
@@ -52,7 +52,10 @@ const LatestUserInfo: React.FC<LatestUserInfoProps> = ({
         승률 {user.winRate}%
       </p>
       <button
-        onClick={() => onAddUser(user)}
+        onClick={(e) => {
+          onAddUser(user);
+          e.stopPropagation();
+        }}
         className="w-[10px] bg-inherit text-white"
       >
         +

--- a/client/src/components/Mobile/userModal/UserModal.tsx
+++ b/client/src/components/Mobile/userModal/UserModal.tsx
@@ -36,7 +36,7 @@ const UserModal = ({ user, setUserModal, setIsUserAdded }: Props) => {
       <Link
         to="/ProfilePage"
         className="no-underline text-black"
-        state={user.id}
+        state={{ user_id: user.id }}
       >
         프로필 확인하기
       </Link>

--- a/client/src/page/MainPage.tsx
+++ b/client/src/page/MainPage.tsx
@@ -37,6 +37,10 @@ const MainPage = () => {
   const handleAddUser = (user: User) => {
     const selectedUser = allUsers.find((u) => u.id === user.id);
     if (!selectedUser) return;
+    if (addedUsers.length > 9) {
+      alert("사용자는 10명 이상 추가할 수 없습니다!");
+      return;
+    }
 
     // Redteam -> BlueTeam 순서로 추가
     if (redTeam.length <= blueTeam.length) {

--- a/client/src/page/ProfilePage.tsx
+++ b/client/src/page/ProfilePage.tsx
@@ -1,5 +1,6 @@
 // ProfilePage.tsx
 import React from "react";
+import { useLocation } from "react-router-dom";
 import Menu from "../components/Profile/menu";
 import ProfileHeader from "../components/Profile/ProfileHeader";
 import ProfileStats from "../components/Profile/ProfileStats";
@@ -12,13 +13,15 @@ import tierImgD from "../assets/modeGif/Rank=Diamond.png";
 import tierImgG from "../assets/modeGif/Rank=Grandmaster.png";
 
 const ProfilePage: React.FC = () => {
+  const location = useLocation();
+  const user_id = location.state.user_id;
+  console.log(user_id);
   return (
     <div
       className="bg-cover bg-center text-white min-h-screen p-6 flex justify-center"
       style={{ backgroundImage: `url(${BackImg})` }}
     >
       <div className="w-full max-w-6xl relative">
-        
         {/* 메뉴 영역 */}
         <div className="fixed top-0 left-0 w-full bg-gray-800 bg-opacity-90 z-50 py-4">
           <Menu />
@@ -42,7 +45,9 @@ const ProfilePage: React.FC = () => {
 
           {/* 중앙 영역 */}
           <div className="bg-gray-800 p-6 rounded-lg flex flex-col justify-between border-4 border-[rgb(200, 155, 60)]">
-            <div className="text-center text-2xl font-bold w-full font-blackHanSans">소환사 정보</div>
+            <div className="text-center text-2xl font-bold w-full font-blackHanSans">
+              소환사 정보
+            </div>
             <ProfileHeader />
           </div>
 


### PR DESCRIPTION
- 제목 :[fix] 추가된 user가 10명이 넘을 시, 추가를 하지 못하도록 수정, [fix] 프로필 클릭과, 추가버튼 이벤트 버블링 방지, [feat] user id 값 전달

## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- 이제 유저를 10명 넘게 추가 시 alert를 띄우며 더 이상 추가할 수 없도록 합니다.

- 유저 추가 버튼에 stopPropagation()을 추가하여 프로필 선택 이벤트와 유저 추가 이벤트가 동시에 일어나지 않도록 하였습니다.

- modal에서 프로필 페이지로 이동 시 user_id값을 전달해 프로필에서도 user_id를 이용하여 정보를 불러올 수 있도록 하였습니다.

  <br/>

## 이미지 첨부


<br/>

## 🔧 앞으로의 과제

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
