### PR TITLE
[design] 모달창 띄울 시 주위 없애기/ [design] 데스크탑 로그인 페이지 경고문구 넣기 /[fix] 유저 검색시 잘못된 유저 수정

### DIFF
--- a/client/src/commonTypes.ts
+++ b/client/src/commonTypes.ts
@@ -41,4 +41,5 @@ export interface User {
   gameName: string; // 유저 닉네임
   tagLine: string; // 유저 태그
   winRate: number; // 승률
+  updateId: number;
 }

--- a/client/src/components/Desktop/Login.tsx
+++ b/client/src/components/Desktop/Login.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import { useState, useRef } from "react";
 
 const Login = () => {
   const [isPlaying, setIsPlaying] = useState(true); // 음악 상태 (재생/일시정지)

--- a/client/src/components/Mobile/userModal/UserModal.tsx
+++ b/client/src/components/Mobile/userModal/UserModal.tsx
@@ -10,9 +10,11 @@ interface Props {
 }
 
 const UserModal = ({ user, setUserModal, setIsUserAdded }: Props) => {
+  console.log(user);
+  console.log(user.updateId);
   const reloadInfo = () => {
     const data = {
-      user_id: user.id,
+      user_id: user.updateId,
     };
     apiCall("/noobs/friendUserBrUpdate", "post", data);
     console.log("클릭됨");

--- a/client/src/page/Desktop-LoginPage.tsx
+++ b/client/src/page/Desktop-LoginPage.tsx
@@ -1,10 +1,14 @@
-import React from "react";
 import Login from "../components/Desktop/Login";
 
 const DesktopLoginPage = () => {
   return (
     <>
       <Login />
+      <p className="text-white text-xs absolute right-6 bottom-8">
+        Leagueof Legendsand Riot Games are trademark <br />
+        sor registered trademarksof Riot Games, <br />
+        Inc. Leagueof Legends © Riot Games, Inc.
+      </p>
     </>
   );
 };

--- a/client/src/page/mainPageModal/AddUserModal.tsx
+++ b/client/src/page/mainPageModal/AddUserModal.tsx
@@ -71,7 +71,7 @@ export default function AddUserModal({
   return (
     isModalOpen && (
       <div
-        className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center"
+        className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50"
         onClick={(e) => {
           if (e.target === e.currentTarget) closeModal();
         }}
@@ -112,7 +112,7 @@ export default function AddUserModal({
           )}
           {userAdded === false && (
             <span className="block text-red-500 text-sm mb-4 text-center">
-              닉네임과 태그를 확인해주세요!
+              해당 사용자를 찾을 수 없습니다
             </span>
           )}
 

--- a/client/src/page/mainPageModal/HowToUseModal.tsx
+++ b/client/src/page/mainPageModal/HowToUseModal.tsx
@@ -51,7 +51,7 @@ export default function HowToUseModal({ closeModal }: ModalProps) {
 
   return (
     <div
-      className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center"
+      className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50"
       onClick={(e) => {
         if (e.target === e.currentTarget) closeModal();
       }}

--- a/client/src/page/mainPageModal/SelectModeModal.tsx
+++ b/client/src/page/mainPageModal/SelectModeModal.tsx
@@ -52,7 +52,7 @@ export default function SelectModeModal({
 
   return (
     <div
-      className="fixed inset-0 bg-black bg-opacity-70 flex justify-center items-center font-blackHanSans"
+      className="fixed inset-0 bg-black bg-opacity-70 flex justify-center items-center font-blackHanSans z-50"
       onClick={(e) => {
         if (e.target === e.currentTarget) closeModal();
       }}


### PR DESCRIPTION
- 제목 : [design] 모달창 띄울 시 주위 없애기/ [design] 데스크탑 로그인 페이지 경고문구 넣기 /[fix] 유저 검색시 잘 못된 유저 수정

## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- 사용법, 인원추가 , 모드 선택 모달 열시에 백그라운드 뿌옇게 처리했습니다.

- 데스크탑 로그인 페이지에 라이엇에서 지정한 경고문구 추가하였습니다.

- 유저 검색 시 잘못된 유저 입력시 경고문구 추가하였습니다.

  <br/>

## 이미지 첨부


<br/>

## 🔧 앞으로의 과제

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
