### PR TITLE
[fix] 유저 삭제시 라인정보 남아있는거 수정

### DIFF
--- a/client/src/components/Desktop/BlueTeam.tsx
+++ b/client/src/components/Desktop/BlueTeam.tsx
@@ -100,6 +100,7 @@ const BlueTeam: React.FC<BlueTeamProps> = ({
               onClick={() => {
                 handleRemoveUser(user);
                 handleAddUser(user);
+                setLineSrc(none);
               }}
             />
           </div>

--- a/client/src/components/Desktop/RedTeam.tsx
+++ b/client/src/components/Desktop/RedTeam.tsx
@@ -100,6 +100,7 @@ const RedTeam: React.FC<RedTeamProps> = ({
               className="w-5 h-5 cursor-pointer"
               onClick={() => {
                 handleRemoveUser(user);
+                setLineSrc(none);
                 handleAddUser(user);
               }}
             />

--- a/client/src/components/Mobile/chooseUser/AddedUserInfo.tsx
+++ b/client/src/components/Mobile/chooseUser/AddedUserInfo.tsx
@@ -55,7 +55,9 @@ const UserInfo: React.FC<AddedUserInfoProps> = ({
       </p>
       <button
         className="w-[10px] bg-inherit text-white"
-        onClick={() => onRemoveUser(user)}
+        onClick={() => {
+          onRemoveUser(user), setLineSrc(none);
+        }}
       >
         X
       </button>


### PR DESCRIPTION
- 제목 : [fix] 유저 삭제시 라인정보 남아있는거 수정

## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- 유저를 삭제하고 다시 등록해도 이전에 등록한 라인정보가 남아있는 오류를 수정했습니다.

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 과제

- 라인별로 하나씩만 존재하도록 수정

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
